### PR TITLE
Add times sprints tutorials

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -14,7 +14,7 @@ const En: Lang = {
     VENUE_INFO: "Venue Info",
     TUTORIAL_DATE: "OCTOBER 26, 2023 (11:00 - 17:30)",
     CONFERENCE_DATE: "OCTOBER 27 - 28, 2023 (9:00 - 18:00)",
-    SPRINT_DATE: "OCTOBER 29, 2023i (10:00 - 18:00)",
+    SPRINT_DATE: "OCTOBER 29, 2023 (10:00 - 18:00)",
     TICKET_INFO: "Ticket Info",
   },
   MENU: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -12,9 +12,9 @@ const En: Lang = {
     VENUE: "TOC Ariake Convention Hall",
     VENUE_SPRINT: "HENNGE K.K.",
     VENUE_INFO: "Venue Info",
-    TUTORIAL_DATE: "OCTOBER 26, 2023",
-    CONFERENCE_DATE: "OCTOBER 27 - 28, 2023",
-    SPRINT_DATE: "OCTOBER 29, 2023",
+    TUTORIAL_DATE: "OCTOBER 26, 2023 (11:00 - 17:30)",
+    CONFERENCE_DATE: "OCTOBER 27 - 28, 2023 (9:00 - 18:00)",
+    SPRINT_DATE: "OCTOBER 29, 2023i (10:00 - 18:00)",
     TICKET_INFO: "Ticket Info",
   },
   MENU: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -12,9 +12,9 @@ const Ja: Lang = {
     VENUE: "TOC有明コンベンションホール",
     VENUE_SPRINT: "HENNGE株式会社",
     VENUE_INFO: "会場案内",
-    TUTORIAL_DATE: "2023.10.26(Thu)",
-    CONFERENCE_DATE: "2023.10.27(Fri)-28(Sat)",
-    SPRINT_DATE: "2023.10.29(Sun)",
+    TUTORIAL_DATE: "2023.10.26(Thu) (11:00 - 17:30)",
+    CONFERENCE_DATE: "2023.10.27(Fri)-28(Sat) (9:00 - 18:00)",
+    SPRINT_DATE: "2023.10.29(Sun) (10:00 - 18:00)",
     TICKET_INFO: "チケット案内",
   },
   MENU: {


### PR DESCRIPTION
I am not sure if this is allowed. The time information is missing from the front page, and some of it is only available in blog posts. I thought  it would be better to have a summary of the times available on the front page. Please change as needed or reject if not appropriate.