### PR TITLE
トラック5のケースでもスライドURL取得するように変更

### DIFF
--- a/src/pages/timetable.tsx
+++ b/src/pages/timetable.tsx
@@ -129,6 +129,7 @@ export const getStaticProps = async () => {
   const short = await fetchTalks(SUBMISSION_TYPE_SHORT_TALK)
     .then(sessions => sessions.map(session => {
       session.content_locale = ['日本語', 'Japanese'].includes(contentLocales[session.code]) ? 'ja-jp' : 'en';
+      session.slide_url = slideUrls[session.code] ? slideUrls[session.code] : null;
       return session;
     }));
 


### PR DESCRIPTION
コードを確認したところ、トラック5のケースではURL取得が漏れていたためほかのトラックと同様にURLを取得する処理を入れました。
ローカルでトラック5で発表した自分の発表に対して表示確認を行ったところ、スライドリンクが表示され修正できていることを確認しました。
Day 1, Day 2のほかの発表についてもいくつか開いて確認しましたが、スライドリンクが表示され修正できていることを確認しました。


![image](https://github.com/pyconjp/pycon.jp.2023/assets/6592904/d2dffbd2-5aa6-4a1d-9a78-34bbb632f2ca)
